### PR TITLE
Setters for numerator and denominator

### DIFF
--- a/Fraction.py
+++ b/Fraction.py
@@ -47,7 +47,8 @@ class Fraction(object):
     @denominator.setter
     def denominator(self, new_denominator):
         gcd = Fraction.gcd(new_denominator, self.numerator)
-        self._denominator = new_denominator // gcd
+        # denominator should ALWAYS be positive
+        self._denominator = abs(new_denominator) // gcd
         self._numerator //= gcd
 
     def get_numerator(self):

--- a/Fraction.py
+++ b/Fraction.py
@@ -56,11 +56,14 @@ class Fraction(object):
     def denominator(self, new_denominator):
         if new_denominator == 0:
             raise ZeroDivisionError("Denominator must not be zero")
-        sign = 1 if new_denominator * self._numerator >= 0 else -1
-        gcd = Fraction.gcd(new_denominator, self.numerator)
-        self._denominator = abs(new_denominator) // gcd
-        # only numerator can be negative
-        self._numerator = (sign * abs(self._numerator)) // gcd
+        if self.numerator == 0:
+            self._denominator = 1
+        else:
+            sign = 1 if new_denominator * self._numerator >= 0 else -1
+            gcd = Fraction.gcd(new_denominator, self.numerator)
+            self._denominator = abs(new_denominator) // gcd
+            # only numerator can be negative
+            self._numerator = (sign * abs(self._numerator)) // gcd
 
     def get_numerator(self):
 

--- a/Fraction.py
+++ b/Fraction.py
@@ -47,6 +47,8 @@ class Fraction(object):
 
     @denominator.setter
     def denominator(self, new_denominator):
+        if new_denominator == 0:
+            raise ZeroDivisionError("Denominator must not be zero")
         sign = 1 if new_denominator * self._numerator >= 0 else -1
         gcd = Fraction.gcd(new_denominator, self.numerator)
         self._denominator = abs(new_denominator) // gcd

--- a/Fraction.py
+++ b/Fraction.py
@@ -36,10 +36,17 @@ class Fraction(object):
 
     @numerator.setter
     def numerator(self, new_numerator):
-        sign = 1 if new_numerator * self.denominator >= 0 else -1
-        gcd = Fraction.gcd(new_numerator, self.denominator)
-        self._numerator = (sign * abs(new_numerator)) // gcd
-        self._denominator //= gcd
+        if new_numerator == 0:
+            self._numerator = 0
+            # denominator must be zero
+            # to avoid wrong GCD
+            # when setting a non-zero numerator again
+            self._denominator = 1
+        else:
+            sign = 1 if new_numerator * self.denominator >= 0 else -1
+            gcd = Fraction.gcd(new_numerator, self.denominator)
+            self._numerator = (sign * abs(new_numerator)) // gcd
+            self._denominator //= gcd
 
     @property
     def denominator(self):

--- a/Fraction.py
+++ b/Fraction.py
@@ -36,8 +36,9 @@ class Fraction(object):
 
     @numerator.setter
     def numerator(self, new_numerator):
+        sign = 1 if new_numerator * self.denominator >= 0 else -1
         gcd = Fraction.gcd(new_numerator, self.denominator)
-        self._numerator = new_numerator // gcd
+        self._numerator = (sign * abs(new_numerator)) // gcd
         self._denominator //= gcd
 
     @property
@@ -46,10 +47,11 @@ class Fraction(object):
 
     @denominator.setter
     def denominator(self, new_denominator):
+        sign = 1 if new_denominator * self._numerator >= 0 else -1
         gcd = Fraction.gcd(new_denominator, self.numerator)
-        # denominator should ALWAYS be positive
         self._denominator = abs(new_denominator) // gcd
-        self._numerator //= gcd
+        # only numerator can be negative
+        self._numerator = (sign * abs(self._numerator)) // gcd
 
     def get_numerator(self):
 


### PR DESCRIPTION
**Changelogs**
- The new setters for `numerator` and `denominator` make it so that assigning `self.numerator` or `self.denominator` automatically converts the fraction to lowest terms along with giving it the proper sign in the numerator.
- Setting numerator to 0 makes the fraction 0/1
- Setting denominator to 0 returns an error.