### PR TITLE
Init fraction

### DIFF
--- a/Fraction.py
+++ b/Fraction.py
@@ -3,8 +3,6 @@ class Fraction(object):
     def __init__(self, numerator=0, denominator=1):
         if denominator == 0:
             raise ZeroDivisionError("Denominator should not be zero.")
-        if not isinstance(denominator, int):
-            raise ValueError("Denominator should be an integer")
 
         # initial values of fraction just to avoid errors
         # with setters
@@ -13,15 +11,16 @@ class Fraction(object):
 
         if isinstance(numerator, str):
             numbers = numerator.split("/")
-            if len(numbers) > 2 or len(numbers) < 1:
-                raise ValueError("Invalid string passed")
+            if len(numbers) > 0 and len(numbers) <= 2:
+                try:
+                    self.numerator = int(numbers[0])
+                    # denominator is passed
+                    if len(numbers) == 2:
+                        self.denominator = int(numbers[1])
+                except ValueError:
+                    print("Invalid string passed, fraction will be set to 0")
 
-            self.numerator = int(numbers[0])
-            # denominator is passed
-            if len(numbers) == 2:
-                self.denominator = int(numbers[1])
-
-        if isinstance(numerator, int):
+        if isinstance(numerator, int) and isinstance(denominator, int):
             self.numerator = numerator
             self.denominator = denominator
 

--- a/Fraction.py
+++ b/Fraction.py
@@ -12,9 +12,14 @@ class Fraction(object):
         self._denominator = 1
 
         if isinstance(numerator, str):
-            num, denom = numerator.split("/")
-            self.numerator = int(num)
-            self.denominator = int(denom)
+            numbers = numerator.split("/")
+            if len(numbers) > 2 or len(numbers) < 1:
+                raise ValueError("Invalid string passed")
+
+            self.numerator = int(numbers[0])
+            # denominator is passed
+            if len(numbers) == 2:
+                self.denominator = int(numbers[1])
 
         if isinstance(numerator, int):
             self.numerator = numerator

--- a/Fraction.py
+++ b/Fraction.py
@@ -6,6 +6,11 @@ class Fraction(object):
         if not isinstance(denominator, int):
             raise ValueError("Denominator should be an integer")
 
+        # initial values of fraction just to avoid errors
+        # with setters
+        self._numerator = 0
+        self._denominator = 1
+
         if isinstance(numerator, str):
             num, denom = numerator.split("/")
             self.numerator = int(num)


### PR DESCRIPTION
**Changelogs**
- Fraction is 0/1 by default, `_numerator` and `_denominator` are set to 0 and 1 respectively to avoid errors with setters
- `ValueErrors` are no longer thrown, just keep the Fraction as 0/1
- Initializing by string now allows for integer strings (e.g: "123" instead of only strings like "-5/4")